### PR TITLE
Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/lazysignup/views.py
+++ b/lazysignup/views.py
@@ -5,7 +5,7 @@ from django.shortcuts import redirect, render
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.http import HttpResponseBadRequest
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.module_loading import import_string
 
 from lazysignup.decorators import allow_lazy_user


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0

Replace `ugettext_lazy` with `gettext_lazy`